### PR TITLE
Refactor lineup validation

### DIFF
--- a/src/spell-checker/utils.ts
+++ b/src/spell-checker/utils.ts
@@ -466,7 +466,7 @@ export async function sendGoogleAdsErrorReports(errors: { spelling: any[], capit
 }
 
 
-export   function checkIfLineupExists(html: string): boolean {
+export   function checkIfLineupExists(html: string, url?: string): boolean {
     const  lineupClassNames = ['PartnerLists_container__hmkhb PartnerLists_open__WAh6E PartnerList_list__5eMzn',
         'partnersArea_main-partner-list', 'ConditionalPartnersList', 'test-id-partners-list',
         'homePage_partners-list-section', 'articlesSection_container', 'partnerNode', 'Partner', 'partner' ];
@@ -487,7 +487,13 @@ export   function checkIfLineupExists(html: string): boolean {
   const foundInRawHtml = lineupClassNames.some(name => html.includes(name));
  
   // ✅ Return true if either found
-  return foundInDOM || foundInRawHtml;
+  const exists = foundInDOM || foundInRawHtml;
+  if (url) {
+    logToCloudWatch(`checkIfLineupExists for ${url}: ${exists}`, 'INFO');
+  } else {
+    logToCloudWatch(`checkIfLineupExists result: ${exists}`, 'INFO');
+  }
+  return exists;
  }
 
 


### PR DESCRIPTION
## Summary
- refactor lineupValidation to alert immediately and avoid extra retry batching
- log checkIfLineupExists results with URL

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest: not found)*